### PR TITLE
Add run specific output directory from the config file

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -590,7 +590,7 @@ void core::config_output(const pt::ptree &value)
         if (out_type == "output_dir")
         {
             // Get dir for output (create if doesn't exist)
-            auto output_dir = itr.second.get<std::string>("path");
+            auto output_dir = itr.second.data();
             auto o_path = cwd_dir / output_dir;
             boost::filesystem::create_directories(o_path);
 


### PR DESCRIPTION
- Need to define the "output_dir" as below
- No longer need to have output folder in mesh base_name (see below)

New file structure:

output_dir/
   meshes/
   points/

```
"output":
  {
    "output_dir":
     {
        "path":"out_test"
     },
    "Bonsai":
     {
       "longitude": -115.21391,
       "latitude": 50.82092,
       "file": "BNS_out.txt",
       "type": "timeseries"
     },
```

...

```
"mesh":
     {
       "base_name":"SC",
       "format": [ "vtu"],
       "variables":["swe"],
       "frequency":1
     }
```
