### PR TITLE
Modify PBSM3D linear solves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,7 +315,7 @@ if(USE_OCL AND OPENCL_FOUND)
        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -framework OpenCL")
     endif()
 else()
-    add_definitions(-Dvcl_scalar_type=float) #might as well default to double precision if no OpenCL device found.
+    add_definitions(-Dvcl_scalar_type=double) #might as well default to double precision if no OpenCL device found.
     unset(OPENCL_LIBRARIES CACHE) ##zero these out so we can use them later without trouble
     unset(OPENCL_INCLUDE_DIRS CACHE)
 endif()

--- a/src/modules/PBSM3D.cpp
+++ b/src/modules/PBSM3D.cpp
@@ -1039,7 +1039,6 @@ void PBSM3D::run(mesh domain)
     chow_patel_ilu_config.jacobi_iters(2); //  Jacobi iterations per triangular 'solve' Rx=r
     viennacl::linalg::chow_patel_ilu_precond< viennacl::compressed_matrix<vcl_scalar_type> > chow_patel_ilu(vl_C, chow_patel_ilu_config);
 
-
     // Set up convergence tolerance to have an average value for each unknown
     double suspension_gmres_tol_per_unknown = 1e-8;
     double suspension_gmres_tol = suspension_gmres_tol_per_unknown * nLayer * ntri;
@@ -1048,10 +1047,10 @@ void PBSM3D::run(mesh domain)
     size_t suspension_gmres_krylov_dimension = 30;
 
     // compute result and copy back to CPU device (if an accelerator was used), otherwise access is slow
-    viennacl::linalg::gmres_tag gmres_tag(suspension_gmres_tol,
-					  suspension_gmres_max_iterations,
-					  suspension_gmres_krylov_dimension);
-    viennacl::vector<vcl_scalar_type> vl_x = viennacl::linalg::solve(vl_C, b,  gmres_tag, chow_patel_ilu);
+    viennacl::linalg::gmres_tag suspension_custom_gmres(suspension_gmres_tol,
+							suspension_gmres_max_iterations,
+							suspension_gmres_krylov_dimension);
+    viennacl::vector<vcl_scalar_type> vl_x = viennacl::linalg::solve(vl_C, b,  suspension_custom_gmres, chow_patel_ilu);
     std::vector<vcl_scalar_type> x(vl_x.size());
     viennacl::copy(vl_x,x);
 

--- a/src/modules/PBSM3D.cpp
+++ b/src/modules/PBSM3D.cpp
@@ -323,9 +323,9 @@ void PBSM3D::run(mesh domain)
 
 
     //zero CSR vector in vl_C
-    viennacl::vector_base<unsigned int> init_temporary(vl_C.handle(), viennacl::compressed_matrix<vcl_scalar_type>::size_type(nnz+1), 0, 1);
+    viennacl::vector_base<vcl_scalar_type> init_temporary(vl_C.handle(), viennacl::compressed_matrix<vcl_scalar_type>::size_type(nnz+1), 0, 1);
     // write:
-    init_temporary = viennacl::zero_vector<unsigned int>(viennacl::compressed_matrix<vcl_scalar_type>::size_type(nnz+1), viennacl::traits::context(vl_C));
+    init_temporary = viennacl::zero_vector<vcl_scalar_type>(viennacl::compressed_matrix<vcl_scalar_type>::size_type(nnz+1), viennacl::traits::context(vl_C));
 
     //zero-fill RHS
     b.clear();
@@ -1105,9 +1105,9 @@ void PBSM3D::run(mesh domain)
     vcl_scalar_type*    A_elements   = viennacl::linalg::host_based::detail::extract_raw_pointer<vcl_scalar_type>(vl_A.handle());
 
     //zero CSR vector in vl_A
-    viennacl::vector_base<unsigned int> init_temporaryA(vl_A.handle(), viennacl::compressed_matrix<vcl_scalar_type>::size_type(nnz_drift+1), 0, 1);
+    viennacl::vector_base<vcl_scalar_type> init_temporaryA(vl_A.handle(), viennacl::compressed_matrix<vcl_scalar_type>::size_type(nnz_drift+1), 0, 1);
     // write:
-    init_temporaryA = viennacl::zero_vector<unsigned int>(viennacl::compressed_matrix<vcl_scalar_type>::size_type(nnz_drift+1), viennacl::traits::context(vl_A));
+    init_temporaryA = viennacl::zero_vector<vcl_scalar_type>(viennacl::compressed_matrix<vcl_scalar_type>::size_type(nnz_drift+1), viennacl::traits::context(vl_A));
 
     //zero fill RHS for drift
     bb.clear();

--- a/src/modules/PBSM3D.cpp
+++ b/src/modules/PBSM3D.cpp
@@ -1040,8 +1040,17 @@ void PBSM3D::run(mesh domain)
     viennacl::linalg::chow_patel_ilu_precond< viennacl::compressed_matrix<vcl_scalar_type> > chow_patel_ilu(vl_C, chow_patel_ilu_config);
 
 
-    //compute result and copy back to CPU device (if an accelerator was used), otherwise access is slow
-    viennacl::linalg::gmres_tag gmres_tag(1e-16, 1000, 30);
+    // Set up convergence tolerance to have an average value for each unknown
+    double suspension_gmres_tol_per_unknown = 1e-8;
+    double suspension_gmres_tol = suspension_gmres_tol_per_unknown * nLayer * ntri;
+    // Set max iterations and maximum Krylov dimension before restart
+    size_t suspension_gmres_max_iterations = 1000;
+    size_t suspension_gmres_krylov_dimension = 30;
+
+    // compute result and copy back to CPU device (if an accelerator was used), otherwise access is slow
+    viennacl::linalg::gmres_tag gmres_tag(suspension_gmres_tol,
+					  suspension_gmres_max_iterations,
+					  suspension_gmres_krylov_dimension);
     viennacl::vector<vcl_scalar_type> vl_x = viennacl::linalg::solve(vl_C, b,  gmres_tag, chow_patel_ilu);
     std::vector<vcl_scalar_type> x(vl_x.size());
     viennacl::copy(vl_x,x);

--- a/src/modules/PBSM3D.cpp
+++ b/src/modules/PBSM3D.cpp
@@ -1054,6 +1054,10 @@ void PBSM3D::run(mesh domain)
     std::vector<vcl_scalar_type> x(vl_x.size());
     viennacl::copy(vl_x,x);
 
+    // Log final state of the linear solve
+    LOG_DEBUG << "Suspension_GMRES # of iterations: " << suspension_custom_gmres.iters();
+    LOG_DEBUG << "Suspension_GMRES final residual : " << suspension_custom_gmres.error();
+
     /*
       Dump matrix to ASCII file
     */
@@ -1221,6 +1225,11 @@ void PBSM3D::run(mesh domain)
     // viennacl::vector<vcl_scalar_type> vl_dSdt = viennacl::linalg::solve(vl_A, bb, laplace_smoothing_custom_cg);
     std::vector<vcl_scalar_type> dSdt(vl_dSdt.size());
     viennacl::copy(vl_dSdt,dSdt);
+
+    // Log final state of the linear solve
+    LOG_DEBUG << "Laplace_Smoothing_CG # of iterations: " << laplace_smoothing_custom_cg.iters();
+    LOG_DEBUG << "Laplace_Smoothing_CG final residual : " << laplace_smoothing_custom_cg.error();
+
 
 #pragma omp parallel for
     for (size_t i = 0; i < domain->size_faces(); i++)

--- a/src/modules/PBSM3D.hpp
+++ b/src/modules/PBSM3D.hpp
@@ -55,6 +55,7 @@ inline int omp_get_max_threads() { return 1;}
 #include <viennacl/linalg/gmres.hpp>
 #include <viennacl/compressed_matrix.hpp>
 #include <viennacl/linalg/ilu.hpp>
+#include <viennacl/linalg/cg.hpp>
 
 
 


### PR DESCRIPTION
Fixes double precision bug.

Updates linear solver properties.

(Note preconditioned CG on symmetric positive definite systems is more efficient than preconditioned GMRES)

