### PR TITLE
Base class for submodules: `base_step`.

### DIFF
--- a/src/modules/submodules/base_step.hpp
+++ b/src/modules/submodules/base_step.hpp
@@ -1,0 +1,15 @@
+#include <concepts>
+
+template<typename T, typename Data>
+concept GuaranteeImplementExecute = requires(T t, Data d) {
+    { t.execute_impl(d) } -> std::same_as<void>;
+};
+
+template<class Derived, class Data>
+    requires GuaranteeImplementExecute<Derived, Data>
+class base_step {
+public:
+    void execute(Data& d) {
+        static_cast<Derived*>(this)->execute_impl(d);
+    }
+};

--- a/src/modules/submodules/base_step.hpp
+++ b/src/modules/submodules/base_step.hpp
@@ -1,3 +1,30 @@
+//
+// Canadian Hydrological Model - The Canadian Hydrological Model (CHM) is a novel
+// modular unstructured mesh based approach for hydrological modelling
+// Copyright (C) 2018 Christopher Marsh
+//
+// This file is part of Canadian Hydrological Model.
+//
+// Canadian Hydrological Model is free software: you can redistribute it and/or
+// modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Canadian Hydrological Model is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Canadian Hydrological Model.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+
+//
+// Created by Donovan Allum 2025
+//
+
 #pragma once
 #include <concepts>
 

--- a/src/modules/submodules/base_step.hpp
+++ b/src/modules/submodules/base_step.hpp
@@ -1,15 +1,19 @@
 #include <concepts>
 
 template<typename T, typename Data>
-concept GuaranteeImplementExecute = requires(T t, Data d) {
+concept GuaranteeImplementExecute = requires(const T& t, Data& d) {
     { t.execute_impl(d) } -> std::same_as<void>;
 };
 
 template<class Derived, class Data>
-    requires GuaranteeImplementExecute<Derived, Data>
 class base_step {
+protected:
+    base_step() {};
 public:
-    void execute(Data& d) {
-        static_cast<Derived*>(this)->execute_impl(d);
+    void execute(Data& d) const {
+        static_assert(GuaranteeImplementExecute<Derived,Data>,
+                "Derived class must implement: void execute_impl(Data&) const");
+        static_cast<const Derived*>(this)->execute_impl(d);
     }
+    ~base_step() {};
 };

--- a/src/modules/submodules/base_step.hpp
+++ b/src/modules/submodules/base_step.hpp
@@ -1,3 +1,26 @@
+/**
+ * @brief Base class for submodules using the Curiously Recurring Template Pattern (CRTP).
+ *
+ * This class enforces that derived classes implement an `execute_impl(Data&) const` method,
+ * and provides a public `execute(Data&) const` method that forwards to the derived implementation.
+ *
+ * The CRTP pattern allows compile-time polymorphism, enabling static dispatch and
+ * avoiding the overhead of virtual functions. This is useful for performance-critical
+ * code or when templates are preferred over inheritance.
+ *
+ * Usage example:
+ * @code
+ * struct MyStep : public base_step<MyStep, MyData> {
+ *     void execute_impl(MyData& d) {
+ *         // Step-specific logic here
+ *     }
+ * };
+ * MyStep step;
+ * MyData data;
+ * step.execute(data); // Calls MyStep::execute_impl(data)
+ * @endcode
+ */
+
 #include <concepts>
 
 template<typename T, typename Data>
@@ -11,8 +34,10 @@ protected:
     base_step() {};
 public:
     void execute(Data& d) const {
+
         static_assert(GuaranteeImplementExecute<Derived,Data>,
                 "Derived class must implement: void execute_impl(Data&) const");
+
         static_cast<const Derived*>(this)->execute_impl(d);
     }
     ~base_step() {};

--- a/src/modules/submodules/base_step.hpp
+++ b/src/modules/submodules/base_step.hpp
@@ -1,3 +1,6 @@
+#pragma once
+#include <concepts>
+
 /**
  * @brief Base class for submodules using the Curiously Recurring Template Pattern (CRTP).
  *
@@ -20,8 +23,6 @@
  * step.execute(data); // Calls MyStep::execute_impl(data)
  * @endcode
  */
-
-#include <concepts>
 
 template<typename T, typename Data>
 concept GuaranteeImplementExecute = requires(const T& t, Data& d) {


### PR DESCRIPTION
# New submodule base class

`base_step` name comes from the idea that submodules are steps in a module.

Uses CRTP to avoid v-table overhead. Derived classes are defined as follows:

```cpp
template<typename data>
class step : public base_step<step,data>
{
public:
    void execute_impl(data& d) const
    {
        // Implementation here
    }
}
```

`data` is intended to be the module specific data class derived from `face_info`.

Derived classses should make use of concepts to enforce getters and setters on data. Example

```cpp
#include <concepts>
template<typename T>
concept StepConcept = requires(const T& t)
{
    { t.input1() } -> std::floating_point;
    { t.input2() } -> std::integral;

    { t.output1(std::declval<double>()) } -> std::same_as<void>
}

template<StepConcept data>
class step : public base_step<step,data>
{
public:
    void execute_impl(data& d) const
    {
        // Implementation here
    }
}
```

At the moment, it is recommended to supply everything via functions, even parameters that are set at run time but never changed.

For parameters that are domain wide one could write a function:

```cpp
const double module::data::foo()
{
    static const double result = cfg.get("result");
    return result;
}
```

Static ensures that the instance is (a) uniform per instance of `data`, and (b) set once (thread safe).

It does involve a hidden bool and if check that is evaluated at runtime on every call.

Parameters that are per-face must have a private variable. Designing submodules derived from `base_step` with getters and setters provides flexibility for the writer.

# Future work

Following this, can merge:

1. A `data` base class. This base class could be combined with `face_info`. It has three uses: (1) providing a constructor for the `data` class to accept a `mesh_elem`, `config_file`, and `global` object. Allows for more detailed control and access to configuration, inputs/outputs, and global variables for submodules. (2) provide a caching system to ensure that inputs and outputs (depends/provides) only dereference the `mesh_elem` object once per time-step, with minimal overhead by the user and memory savings between timesteps. (3) A flexible and inline-able interface for accessing inputs and setting outputs.
2. Submodules derived from `base_step`
3. Modules using these submodules.