### PR TITLE
Fix of deprecated warning 

### DIFF
--- a/src/utility/xxh64.hpp
+++ b/src/utility/xxh64.hpp
@@ -103,13 +103,13 @@ private:
 
 // compile time hash of strings
 #ifndef SAFE_CHECKS
-    constexpr uint64_t operator"" _s(const char* s, std::size_t len)
+    constexpr uint64_t operator""_s(const char* s, std::size_t len)
     {
         return xxh64::hash (s, len);
     }
 
 #else
-    constexpr const char* operator"" _s(const char* s, std::size_t len)
+    constexpr const char* operator""_s(const char* s, std::size_t len)
     {
         return s;
     }


### PR DESCRIPTION
Space between operator keyword and operator symbol produced a repeated warning during compilation.

