### PR TITLE
docs(snobal): fix 'iswr_out' -> 'iswr_net' in provides doc comment

### DIFF
--- a/src/modules/snobal.hpp
+++ b/src/modules/snobal.hpp
@@ -87,7 +87,7 @@ public:
  * - Surface exchange layer temperature "T_s_0" [K]
  * - Lower layer temperature "T_s_l" [K]
  * - Was an iteration error hit "dead". Diagnostic, don't use. [-]
- * - Net shortwave radiation at the surface. Diagnostic. "iswr_out" [ \f$ W \cdot m^{-2} \f$ ]
+ * - Net shortwave radiation at the surface. Diagnostic. "iswr_net" [ \f$ W \cdot m^{-2} \f$ ]
  * - Binary is the snow isothermal "isothermal" [0,1]
  * - Outgoing longwave radiation "ilwr_out" [ \f$ W \cdot m^{-2} \f$ ]
  * - Total snowpack runoff "sum_snowpack_runoff"


### PR DESCRIPTION
## Summary

\`src/modules/snobal.hpp\` line 90 documents the module's *Net shortwave radiation at the surface* diagnostic as \`\"iswr_out\"\`, but the actual variable published by snobal is \`iswr_net\` — see \`src/modules/snobal.cpp\`:

- \`provides(\"iswr_net\");\`
- \`(*face)[\"iswr_net\"_s] = sbal->S_n;\`  (3 call sites)

\`iswr_out\` is a separate outgoing-shortwave variable, not what this module provides. Fixing the doc so it matches the code.

Closes #162

## Testing

Doc-comment-only change (doxygen header in \`.hpp\`); no code paths touched, no build required for verification.