### PR TITLE
Refactor of NearestNeighborProblem to improve readability

### DIFF
--- a/src/math/LinearAlgebra.cpp
+++ b/src/math/LinearAlgebra.cpp
@@ -67,19 +67,19 @@ namespace math
             m_solution->putScalar(0.0);
         }
 
-        void NearestNeighborProblem::matrixReplaceGlobalValues(global_ordinal_type global_row_idx,
-                                                               global_ordinal_type global_col_idx, double val)
+        void NearestNeighborProblem::matrixReplaceGlobalValues(global_index_type global_row_idx,
+                                                               global_index_type global_col_idx, double val)
         {
             m_matrix->replaceGlobalValues(global_row_idx, tuple(global_col_idx), tuple(val));
         }
 
-        void NearestNeighborProblem::matrixSumIntoGlobalValues(global_ordinal_type global_row_idx,
-                                                               global_ordinal_type global_col_idx, double val)
+        void NearestNeighborProblem::matrixSumIntoGlobalValues(global_index_type global_row_idx,
+                                                               global_index_type global_col_idx, double val)
         {
             m_matrix->sumIntoGlobalValues(global_row_idx, tuple(global_col_idx), tuple(val));
         }
 
-        void NearestNeighborProblem::rhsSumIntoGlobalValue(global_ordinal_type global_idx, double val)
+        void NearestNeighborProblem::rhsSumIntoGlobalValue(global_index_type global_idx, double val)
         {
             // Critical section needed because sumIntoGlobalValues is not respecting
             // the 4th arg (force atomic update)

--- a/src/math/LinearAlgebra.cpp
+++ b/src/math/LinearAlgebra.cpp
@@ -54,7 +54,8 @@ namespace math
             }
             if (m_solver.is_null())
             {
-                CHM_THROW_EXCEPTION(module_error, "PBSM3D failed to create solver");
+                std::string err = std::format("{} failed to create solver",_module_name);
+                CHM_THROW_EXCEPTION(module_error, err);
             }
         }
 

--- a/src/math/LinearAlgebra.cpp
+++ b/src/math/LinearAlgebra.cpp
@@ -22,144 +22,22 @@
 //
 
 #include "LinearAlgebra.hpp"
+#include <Tpetra_Core.hpp>
 
 namespace math
 {
     namespace LinearAlgebra
     {
-        NearestNeighborProblem::NearestNeighborProblem(mesh& domain, int nLayer) :
-            m_domain(domain), m_nLayer(nLayer)
+        size_t Sizes::total_elements() const { return global * vert_layers; }
+        size_t Sizes::local_elements() const { return local * vert_layers; }
+
+        void NearestNeighborProblem::set_comm_for_parallel()
         {
-            // TODO Accept a communicator on construction
-            m_comm = Tpetra::getDefaultComm();
+                m_comm = Tpetra::getDefaultComm();
+        };
 
-            // Sizes of the domain
-            size_t ntri = domain->size_local_faces();
-            size_t n_global_tri = domain->size_global_faces();
-
-            /*
-          Initialize the local-global index map for the extruded mesh system.
-            */
-            auto global_IDs = domain->get_global_IDs();
-            std::vector<global_ordinal_type> extruded_global_IDs(ntri * nLayer);
-            // Create the global IDs for the extruded system
-            // Ordering:
-            // - mesh elements and then layers successively
-            auto extruded_ID_iterator = extruded_global_IDs.begin();
-            for (int i = 0; i < nLayer; ++i)
-            {
-                std::transform(global_IDs.begin(), global_IDs.end(), extruded_ID_iterator,
-                               [=](int id) -> global_ordinal_type { return i * n_global_tri + id; });
-                extruded_ID_iterator += ntri;
-            }
-
-
-            const size_t numGlobalElements = n_global_tri * nLayer;
-            const auto* data_extruded_IDs = extruded_global_IDs.data();
-            const size_t indexListSize = ntri * nLayer;
-            int indexBase = 0;
-
-            m_map = rcp(new map_type(numGlobalElements, data_extruded_IDs, indexListSize, indexBase, m_comm));
-
-            // loop over locally owned rows, figure out number of neighbors (owned or
-            // otherwise!), and what their global indices are.
-            std::vector<size_t> num_entries(ntri * nLayer, 1);
-            std::vector<std::array<global_ordinal_type, 6>> neighbor_global_idx(ntri * nLayer);
-
-#pragma omp parallel for
-            for (size_t i = 0; i < ntri; ++i)
-            {
-                auto face = domain->face(i);
-                int face_bottom_idx = face->cell_global_id;
-                int face_bottom_local_idx = face->cell_local_id;
-
-                // Lateral neighbors and self
-                for (int layer = 0; layer < nLayer; ++layer)
-                {
-                    int element_idx = n_global_tri * layer + face_bottom_idx;
-                    int local_array_idx = ntri * layer + face_bottom_local_idx;
-                    neighbor_global_idx.at(local_array_idx).at(0) = element_idx;
-
-                    for (int f = 0; f < 3; f++)
-                    {
-                        auto neighbor = face->neighbor(f);
-
-                        if (neighbor != nullptr)
-                        {
-                            int neigh_bottom_idx = neighbor->cell_global_id;
-                            int neigh_global_idx = n_global_tri * layer + neigh_bottom_idx;
-                            neighbor_global_idx.at(local_array_idx).at(num_entries.at(local_array_idx)) =
-                                neigh_global_idx;
-                            ++num_entries.at(local_array_idx);
-                        }
-                    }
-                }
-                /*
-                  Above and below neighbor loops are null when single layer
-                */
-                // Neighbor below
-                for (int layer = 1; layer < nLayer; ++layer)
-                {
-                    int element_idx = n_global_tri * layer + face_bottom_idx;
-                    int local_array_idx = ntri * layer + face_bottom_local_idx;
-                    int below_idx = n_global_tri * (layer - 1) + face_bottom_idx;
-                    neighbor_global_idx.at(local_array_idx).at(num_entries.at(local_array_idx)) = below_idx;
-                    ++num_entries.at(local_array_idx);
-                }
-                // Neighbor above
-                for (int layer = 0; layer < nLayer - 1; ++layer)
-                {
-                    int element_idx = n_global_tri * layer + face_bottom_idx;
-                    int local_array_idx = ntri * layer + face_bottom_local_idx;
-                    int above_idx = n_global_tri * (layer + 1) + face_bottom_idx;
-                    neighbor_global_idx.at(local_array_idx).at(num_entries.at(local_array_idx)) = above_idx;
-                    ++num_entries.at(local_array_idx);
-                }
-            }
-
-            /*
-          Set up the CrsGraph structure for creating the distributed CrsMatrix and
-          Vectors for the linear nearest neighbor system
-
-          Graph for nearest neighbor connectivity.
-          6 entries (max) per row: self, three neighbors, above and below
-          (fewer entries for boundary elements)
-
-          Preferred construction of CrsGraph uses a Teuchos::ArrayView<T> for num entries/row
-            */
-            Teuchos::ArrayView<size_t> num_entries_view(num_entries.data(), ntri * nLayer);
-            m_graph = rcp(new graph_type(m_map, num_entries_view));
-            // I believe these are all StaticProfile by default now
-
-
-            // Set all of the desired nonzero columns in the graph
-            // due to insertGlobalIndices args
-            // DO NOT DO THIS THREAD PARALLEL
-            for (size_t i = 0; i < ntri; ++i)
-            {
-                auto face = domain->face(i);
-                int face_bottom_idx = face->cell_global_id;
-                int face_bottom_local_idx = face->cell_local_id;
-
-                for (int layer = 0; layer < nLayer; ++layer)
-                {
-                    int element_idx = n_global_tri * layer + face_bottom_idx;
-                    int local_array_idx = ntri * layer + face_bottom_local_idx;
-                    // std::cout << "insertGlobal : " << element_idx << " : " << num_suspension_entries[element_idx] << "\n";
-                    m_graph->insertGlobalIndices(element_idx, num_entries.at(local_array_idx),
-                                                 &(neighbor_global_idx.at(local_array_idx)[0]));
-                }
-            }
-            m_graph->fillComplete();
-
-            // Create a Tpetra::Matrix using the Map, with a static allocation
-            // dictated by NumNz.  (We know exactly how many elements there will
-            // be in each row, so we use static profile for efficiency.)
-            m_matrix = rcp(new crs_matrix_type(m_graph));
-            m_matrix->fillComplete();
-            m_rhs = rcp(new MV(m_map, 1));
-            m_solution = rcp(new MV(m_map, m_rhs->getNumVectors()));
-
+        void NearestNeighborProblem::build_Belos_solver()
+        {
             /*
           Belos solver and Ifpack2 preconditioner setup
           - TODO add optional input to set these params
@@ -178,28 +56,7 @@ namespace math
             {
                 CHM_THROW_EXCEPTION(module_error, "PBSM3D failed to create solver");
             }
-
-            m_preconditioner = Ifpack2::Factory::create<row_matrix_type>("ILUT", m_matrix);
-            if (m_preconditioner.is_null())
-            {
-                CHM_THROW_EXCEPTION(module_error, "PBSM3D failed to create preconditioner");
-            }
-            ParameterList precondOptions;
-            precondOptions.set("fact: drop tolerance", 1e-4);
-            precondOptions.set("fact: ilut level-of-fill", 3.0);
-            // Note this is different from num_entries_per_row: https://docs.trilinos.org/dev/packages/ifpack2/doc/html/classIfpack2_1_1ILUT.html#aee2011b313e3070ee43b2cfc2d183634
-            m_preconditioner->setParameters(precondOptions);
-            m_preconditioner->initialize();
-
-            // Specify the deposition problem
-            m_problem = rcp(new problem_type(m_matrix, m_solution, m_rhs));
-            if (!m_preconditioner.is_null())
-            {
-                m_problem->setRightPrec(m_preconditioner);
-            }
-            m_problem->setProblem();
-            m_solver->setProblem(m_problem);
-        } // end constructor
+        }
 
         void NearestNeighborProblem::zeroSystem()
         {
@@ -304,5 +161,6 @@ namespace math
         NearestNeighborProblem::~NearestNeighborProblem()
         {
         }
-    }
+
+    } // namespace LinearAlgebra
 }

--- a/src/math/LinearAlgebra.hpp
+++ b/src/math/LinearAlgebra.hpp
@@ -130,15 +130,15 @@ namespace math
 
             void zeroSystem();
 
-            void matrixReplaceGlobalValues(global_ordinal_type global_row_idx, global_ordinal_type global_col_idx,
+            void matrixReplaceGlobalValues(global_index_type global_row_idx, global_index_type global_col_idx,
                                            double val);
-            void matrixSumIntoGlobalValues(global_ordinal_type global_row_idx, global_ordinal_type global_col_idx,
+            void matrixSumIntoGlobalValues(global_index_type global_row_idx, global_index_type global_col_idx,
                                            double val);
 
             void matrixResumeFill();
             void matrixFillComplete();
 
-            void rhsSumIntoGlobalValue(global_ordinal_type global_idx, double val);
+            void rhsSumIntoGlobalValue(global_index_type global_idx, double val);
 
             SolveConverge Solve();
 
@@ -166,7 +166,7 @@ namespace math
         RCP<const map_type> NearestNeighborProblem::init_local_global_index_map(M& domain, const Sizes& sizes)
         {
 	    auto global_IDs = domain->get_global_IDs();
-            std::vector<global_ordinal_type> extruded_global_IDs(sizes.local_elements());
+            std::vector<global_index_type> extruded_global_IDs(sizes.local_elements());
             // Create the global IDs for the extruded system
             // Ordering:
             // - mesh elements and then layers successively
@@ -174,7 +174,7 @@ namespace math
             for (int i = 0; i < sizes.vert_layers; ++i)
             {
                 std::transform(global_IDs.begin(), global_IDs.end(), extruded_ID_iterator,
-                               [=](int id) -> global_ordinal_type { return i * sizes.global + id; });
+                               [=](int id) -> global_index_type { return i * sizes.global + id; });
                 extruded_ID_iterator += sizes.local;
             }
 
@@ -189,7 +189,7 @@ namespace math
         struct IndexTracker
         {
             std::vector<size_t> entries_per_element;
-            std::vector<std::array<global_ordinal_type,6>> neighbor_global_idx;
+            std::vector<std::array<global_index_type,6>> neighbor_global_idx;
 
             template <class M> IndexTracker(M& domain, Sizes& sizes);
         };

--- a/src/math/LinearAlgebra.hpp
+++ b/src/math/LinearAlgebra.hpp
@@ -61,9 +61,8 @@ namespace math
         using solver_type = Belos::SolverManager<scalar_type, MV, OP>;
         using reader_type = Tpetra::MatrixMarket::Reader<crs_matrix_type>;
         // The type used for indexes on the local rank
-        using global_ordinal_type = Tpetra::Details::DefaultTypes::global_ordinal_type;
-        using local_ordinal_type = Tpetra::Details::DefaultTypes::local_ordinal_type;
-
+        using global_index_type = Tpetra::Map<>::global_ordinal_type;
+        using local_index_type = Tpetra::Map<>::local_ordinal_type;
 
         struct IndexTracker;
 

--- a/src/math/LinearAlgebra.hpp
+++ b/src/math/LinearAlgebra.hpp
@@ -123,9 +123,11 @@ namespace math
             RCP<prec_type> m_preconditioner;
             RCP<problem_type> m_problem;
 
+            std::string_view _module_name;
+
         public:
 			template<MeshObject M>
-            NearestNeighborProblem(M& domain, int nLayer = 1);
+            NearestNeighborProblem(M& domain, const std::string& module_name, int nLayer = 1);
             ~NearestNeighborProblem();
 
             void zeroSystem();
@@ -323,7 +325,8 @@ namespace math
             m_solver->setProblem(m_problem);
         }
         template <MeshObject M>
-	NearestNeighborProblem::NearestNeighborProblem(M& domain, int nLayer)
+	    NearestNeighborProblem::NearestNeighborProblem(M& domain, const std::string& module_name, int nLayer) 
+            : _module_name(module_name)
         {
             set_comm_for_parallel();
 

--- a/src/math/LinearAlgebra.hpp
+++ b/src/math/LinearAlgebra.hpp
@@ -137,9 +137,6 @@ namespace math
             void matrixSumIntoGlobalValues(global_index_type global_row_idx, global_index_type global_col_idx,
                                            double val);
 
-            void matrixResumeFill();
-            void matrixFillComplete();
-
             void rhsSumIntoGlobalValue(global_index_type global_idx, double val);
 
             SolveConverge Solve();

--- a/src/math/LinearAlgebra.hpp
+++ b/src/math/LinearAlgebra.hpp
@@ -32,7 +32,7 @@
 #include <Teuchos_TimeMonitor.hpp>
 #include <Tpetra_Core.hpp>
 #include <Tpetra_CrsMatrix.hpp>
-
+#include <concepts>
 #include "triangulation.hpp"
 
 
@@ -40,7 +40,7 @@ namespace math
 {
     namespace LinearAlgebra
     {
-        // Typedefs/aliases for ease of Trilinos use
+    // Typedefs/aliases for ease of Trilinos use
         using Teuchos::arcp;
         using Teuchos::ArrayRCP;
         using Teuchos::Comm;
@@ -65,17 +65,49 @@ namespace math
         using local_ordinal_type = Tpetra::Details::DefaultTypes::local_ordinal_type;
 
 
+        struct IndexTracker;
+
         struct SolveConverge
         {
             int numIters;
             double residual;
         };
+		
+        template<typename T>
+        concept MeshObject = requires(T& t,size_t i)
+        {
+                {t->size_local_faces()} -> std::convertible_to<size_t>;
+                {t->size_global_faces()} -> std::convertible_to<size_t>;
+                {t->get_global_IDs()} -> std::ranges::range;
+            requires std::convertible_to<
+                        std::ranges::range_value_t<decltype(t->get_global_IDs())>,
+                        int
+                        >;
+                {t->face(i)} -> std::same_as<mesh_elem>;
+        };
+
+        struct Sizes
+        {
+            size_t local;
+            size_t global;
+            size_t vert_layers;
+            size_t total_elements() const;
+            size_t local_elements() const;
+        };
 
         class NearestNeighborProblem
         {
-            // Unstructured triangular mesh with nLayer extrusion
-            mesh& m_domain;
-            int m_nLayer; // defaults to 1 in constructor
+            void set_comm_for_parallel();
+            template<MeshObject M> static Sizes set_domain_sizes(M&,size_t N);
+
+            template<MeshObject M>
+            RCP<const map_type> init_local_global_index_map(M&,const Sizes&);
+            template <MeshObject M> RCP<graph_type> init_m_graph(M& domain,IndexTracker&, Sizes& sizes);
+            template <MeshObject M> void set_nonzero_elements(M& domain, const IndexTracker&, const Sizes& sizes);
+            template <MeshObject M> void fill_matrix_rhs_solution();
+            template <MeshObject M> void set_problem();
+
+            void build_Belos_solver();
 
             // Trilinos structures for linear system variables
             RCP<const Comm<int>> m_comm;
@@ -93,7 +125,8 @@ namespace math
             RCP<problem_type> m_problem;
 
         public:
-            NearestNeighborProblem(mesh& domain, int nLayer = 1);
+			template<MeshObject M>
+            NearestNeighborProblem(M& domain, int nLayer = 1);
             ~NearestNeighborProblem();
 
             void zeroSystem();
@@ -119,5 +152,197 @@ namespace math
             void writeSystemMatrixMarket(std::string file_prefix);
             void writeSolutionMatrixMarket(std::string file_prefix);
         };
+		
+        template<MeshObject M>
+        Sizes NearestNeighborProblem::set_domain_sizes(M& domain,size_t numLayer)
+        {
+            Sizes s;
+            s.local = domain->size_local_faces();
+            s.global = domain->size_global_faces();
+            s.vert_layers = numLayer;
+            return s;
+        }
+
+        template <MeshObject M>
+        RCP<const map_type> NearestNeighborProblem::init_local_global_index_map(M& domain, const Sizes& sizes)
+        {
+	    auto global_IDs = domain->get_global_IDs();
+            std::vector<global_ordinal_type> extruded_global_IDs(sizes.local_elements());
+            // Create the global IDs for the extruded system
+            // Ordering:
+            // - mesh elements and then layers successively
+            auto extruded_ID_iterator = extruded_global_IDs.begin();
+            for (int i = 0; i < sizes.vert_layers; ++i)
+            {
+                std::transform(global_IDs.begin(), global_IDs.end(), extruded_ID_iterator,
+                               [=](int id) -> global_ordinal_type { return i * sizes.global + id; });
+                extruded_ID_iterator += sizes.local;
+            }
+
+
+            const size_t numGlobalElements = sizes.global * sizes.vert_layers;
+            const size_t indexListSize = sizes.local * sizes.vert_layers;
+            int indexBase = 0;
+
+            return rcp(new map_type(numGlobalElements, extruded_global_IDs.data(), indexListSize, indexBase, m_comm));
+	};
+
+        struct IndexTracker
+        {
+            std::vector<size_t> entries_per_element;
+            std::vector<std::array<global_ordinal_type,6>> neighbor_global_idx;
+
+            template <class M> IndexTracker(M& domain, Sizes& sizes);
+        };
+
+        template <class M> IndexTracker::IndexTracker(M& domain, Sizes& sizes)
+        {
+#pragma omp parallel for
+            for (size_t i = 0; i < sizes.local; ++i)
+            {
+                auto face = domain->face(i);
+                int face_bottom_idx = face->cell_global_id;
+                int face_bottom_local_idx = face->cell_local_id;
+
+                // Lateral neighbors and self
+                for (int layer = 0; layer < sizes.vert_layers; ++layer)
+                {
+                    int element_idx = sizes.global * layer + face_bottom_idx;
+                    int local_array_idx = sizes.local * layer + face_bottom_local_idx;
+                    neighbor_global_idx.at(local_array_idx).at(0) = element_idx;
+
+                    for (int f = 0; f < 3; f++)
+                    {
+                        auto neighbor = face->neighbor(f);
+
+                        if (neighbor != nullptr)
+                        {
+                            int neigh_bottom_idx = neighbor->cell_global_id;
+                            int neigh_global_idx = sizes.global * layer + neigh_bottom_idx;
+                            neighbor_global_idx.at(local_array_idx).at(entries_per_element.at(local_array_idx)) =
+                                neigh_global_idx;
+                            ++entries_per_element.at(local_array_idx);
+                        }
+                    }
+                }
+                /*
+                  Above and below neighbor loops are null when single layer
+                */
+                // Neighbor below
+                for (int layer = 1; layer < sizes.vert_layers; ++layer)
+                {
+                    int element_idx = sizes.global * layer + face_bottom_idx;
+                    int local_array_idx = sizes.local * layer + face_bottom_local_idx;
+                    int below_idx = sizes.global * (layer - 1) + face_bottom_idx;
+                    neighbor_global_idx.at(local_array_idx).at(entries_per_element.at(local_array_idx)) = below_idx;
+                    ++entries_per_element.at(local_array_idx);
+                }
+                // Neighbor above
+                for (size_t layer = 0; layer < sizes.vert_layers - 1; ++layer)
+                {
+                    size_t element_idx = sizes.global * layer + face_bottom_idx;
+                    size_t local_array_idx = sizes.local * layer + face_bottom_local_idx;
+                    size_t above_idx = sizes.global * (layer + 1) + face_bottom_idx;
+                    neighbor_global_idx.at(local_array_idx).at(entries_per_element.at(local_array_idx)) = above_idx;
+                    ++entries_per_element.at(local_array_idx);
+                }
+            }
+        }
+        template <MeshObject M>
+	RCP<graph_type> NearestNeighborProblem::init_m_graph(M& domain,IndexTracker& idx_tracker, Sizes& sizes)
+	{
+
+            /*
+          Set up the CrsGraph structure for creating the distributed CrsMatrix and
+          Vectors for the linear nearest neighbor system
+
+          Graph for nearest neighbor connectivity.
+          6 entries (max) per row: self, three neighbors, above and below
+          (fewer entries for boundary elements)
+
+          Preferred construction of CrsGraph uses a Teuchos::ArrayView<T> for num entries/row
+            */
+            Teuchos::ArrayView<size_t> num_entries_view(idx_tracker.entries_per_element.data(), sizes.local * sizes.vert_layers);
+	    return rcp(new graph_type(m_map,num_entries_view));
+	}
+
+        template <MeshObject M> void NearestNeighborProblem::set_nonzero_elements(M& domain, const IndexTracker& idx_tracker, const Sizes& sizes)
+        {
+            // DO NOT DO THIS THREAD PARALLEL
+            for (size_t i = 0; i < sizes.local; ++i)
+            {
+                auto face = domain->face(i);
+                int face_bottom_idx = face->cell_global_id;
+                int face_bottom_local_idx = face->cell_local_id;
+
+                for (int layer = 0; layer < sizes.vert_layers; ++layer)
+                {
+                    int element_idx = sizes.global * layer + face_bottom_idx;
+                    int local_array_idx = sizes.local * layer + face_bottom_local_idx;
+                    // std::cout << "insertGlobal : " << element_idx << " : " << num_suspension_entries[element_idx] <<
+                    // "\n";
+                    m_graph->insertGlobalIndices(element_idx, idx_tracker.entries_per_element.at(local_array_idx),
+                                                 &(idx_tracker.neighbor_global_idx.at(local_array_idx)[0]));
+                }
+            }
+            m_graph->fillComplete();
+        }
+
+        template <MeshObject M> void NearestNeighborProblem::fill_matrix_rhs_solution()
+        {
+            // Create a Tpetra::Matrix using the Map, with a static allocation
+            // dictated by NumNz.  (We know exactly how many elements there will
+            // be in each row, so we use static profile for efficiency.)
+            m_matrix = rcp(new crs_matrix_type(m_graph));
+            m_matrix->fillComplete();
+            m_rhs = rcp(new MV(m_map, 1));
+            m_solution = rcp(new MV(m_map, m_rhs->getNumVectors()));
+        }
+
+        template <MeshObject M> void NearestNeighborProblem::set_problem()
+        {
+            m_preconditioner = Ifpack2::Factory::create<row_matrix_type>("ILUT", m_matrix);
+            if (m_preconditioner.is_null())
+            {
+                CHM_THROW_EXCEPTION(module_error, "PBSM3D failed to create preconditioner");
+            }
+            ParameterList precondOptions;
+            precondOptions.set("fact: drop tolerance", 1e-4);
+            precondOptions.set("fact: ilut level-of-fill", 3.0);
+            // Note this is different from num_entries_per_row:
+            // https://docs.trilinos.org/dev/packages/ifpack2/doc/html/classIfpack2_1_1ILUT.html#aee2011b313e3070ee43b2cfc2d183634
+            m_preconditioner->setParameters(precondOptions);
+            m_preconditioner->initialize();
+
+            // Specify the deposition problem
+            m_problem = rcp(new problem_type(m_matrix, m_solution, m_rhs));
+            if (!m_preconditioner.is_null())
+            {
+                m_problem->setRightPrec(m_preconditioner);
+            }
+            m_problem->setProblem();
+            m_solver->setProblem(m_problem);
+        }
+        template <MeshObject M>
+	NearestNeighborProblem::NearestNeighborProblem(M& domain, int nLayer)
+        {
+            set_comm_for_parallel();
+
+            auto sizes = set_domain_sizes(domain,nLayer);
+
+            m_map = init_local_global_index_map(domain,sizes);
+
+            IndexTracker idx_tracker{domain,sizes};
+
+            m_graph = init_m_graph(domain,idx_tracker,sizes);
+
+            set_nonzero_elements<M>(domain, idx_tracker, sizes);
+
+            fill_matrix_rhs_solution<M>();
+
+            build_Belos_solver();
+
+            set_problem<M>();
+        }
     }
 }

--- a/src/math/LinearAlgebra.hpp
+++ b/src/math/LinearAlgebra.hpp
@@ -49,20 +49,20 @@ namespace math
         using Teuchos::rcp;
         using Teuchos::Time;
         using Teuchos::tuple;
-        typedef Tpetra::CrsGraph<> graph_type;
-        typedef Tpetra::CrsMatrix<> crs_matrix_type;
-        typedef Tpetra::Map<> map_type;
-        typedef Tpetra::MultiVector<> MV;
-        typedef Tpetra::Operator<> OP;
-        typedef Tpetra::RowMatrix<> row_matrix_type;
-        typedef MV::scalar_type scalar_type;
-        typedef Ifpack2::Preconditioner<> prec_type;
-        typedef Belos::LinearProblem<scalar_type, MV, OP> problem_type;
-        typedef Belos::SolverManager<scalar_type, MV, OP> solver_type;
-        typedef Tpetra::MatrixMarket::Reader<crs_matrix_type> reader_type;
+        using graph_type = Tpetra::CrsGraph<>;
+        using crs_matrix_type = Tpetra::CrsMatrix<>;
+        using map_type = Tpetra::Map<>;
+        using MV = Tpetra::MultiVector<>;
+        using OP = Tpetra::Operator<>;
+        using row_matrix_type = Tpetra::RowMatrix<>;
+        using scalar_type = MV::scalar_type;
+        using prec_type = Ifpack2::Preconditioner<>;
+        using problem_type = Belos::LinearProblem<scalar_type, MV, OP>;
+        using solver_type = Belos::SolverManager<scalar_type, MV, OP>;
+        using reader_type = Tpetra::MatrixMarket::Reader<crs_matrix_type>;
         // The type used for indexes on the local rank
-        typedef Tpetra::Details::DefaultTypes::global_ordinal_type global_ordinal_type;
-        typedef Tpetra::Details::DefaultTypes::local_ordinal_type local_ordinal_type;
+        using global_ordinal_type = Tpetra::Details::DefaultTypes::global_ordinal_type;
+        using local_ordinal_type = Tpetra::Details::DefaultTypes::local_ordinal_type;
 
 
         struct SolveConverge

--- a/src/modules/PBSM3D.cpp
+++ b/src/modules/PBSM3D.cpp
@@ -392,8 +392,8 @@ void PBSM3D::init(mesh& domain)
 
     }
 
-    suspension_NNP.reset(new math::LinearAlgebra::NearestNeighborProblem(domain,nLayer));
-    deposition_NNP.reset(new math::LinearAlgebra::NearestNeighborProblem(domain));
+    suspension_NNP.reset(new math::LinearAlgebra::NearestNeighborProblem(domain,ID,nLayer));
+    deposition_NNP.reset(new math::LinearAlgebra::NearestNeighborProblem(domain,ID));
 
 }
 


### PR DESCRIPTION
In my effort to understand how `NearestNeighborProblem` works, I refactored its constructor for readability. I did change minor behaviour (point 3 below).

Three main changes:

1. Added a template parameter to `NearestNeighborProblem` as a stand-in for `domain`. I did that because I was thinking of testing it, and with the concept called `MeshObject`, I enforce the functions needed at compile time by `NearestNeighborProblem`. Possibly not needed.

2. Added several private helpers and structs to improve the length and readability of the constructor of `NearestNeighborProblem`.

3. Introduced a `_module_name` member to the constructor of type `std::string_view` to allow the printing of the module name in case of throwing an exception. Previously had PBSM3D hard coded (for obvious reasons).