### PR TITLE
Parameters for topo fill coefficients changed to be modifiable

### DIFF
--- a/src/modules/PBSM3D.cpp
+++ b/src/modules/PBSM3D.cpp
@@ -503,37 +503,37 @@ void PBSM3D::run(mesh& domain)
                         // Coefficient for the filling function that give normalized snow depth as a function of TPI
 
                         double a1 = 1.5;
-                        double b1 = 0.3;
-                        double a2 = 0.6;
+                        const double b1 = 0.3;
+                        const double a2 = 0.6;
                         double b2 = 0.55;
                         if (snow_depth > 0.75 and snow_depth < 1.25)
                         {
-                            double a1 = 1.15;
+                            a1 = 1.15;
                         }
                         else if (snow_depth < 1.75)
                         {
-                            double a1 = 1.1;
-                            double b2 = 0.4;
+                            a1 = 1.1;
+                            b2 = 0.4;
                         }
                         else if (snow_depth < 2.25)
                         {
-                            double a1 = 0.9;
-                            double b2 = 0.4;
+                            a1 = 0.9;
+                            b2 = 0.4;
                         }
                         else if (snow_depth < 2.75)
                         {
-                            double a1 = 0.85;
-                            double b2 = 0.4;
+                            a1 = 0.85;
+                            b2 = 0.4;
                         }
                         else if (snow_depth < 3.25)
                         {
-                            double a1 = 0.75;
-                            double b2 = 0.4;
+                            a1 = 0.75;
+                            b2 = 0.4;
                         }
                         else
                         {
-                            double a1 = 0.6;
-                            double b2 = 0.35;
+                            a1 = 0.6;
+                            b2 = 0.35;
                         }
 
                         // Compute normalization factor


### PR DESCRIPTION
a1 and b2 are modified in the if-else statement but they are redeclared, shadowing the original declarations before the if-else. This means that a1 and b2 never actually depend on snow-depth when they are used after the if-else. No idea how often the subgrid topography is used or even this version. 

Just happened to notice it while downloading how it works into my brain. 