### PR TITLE
docs: correct Snobal iswr output name

### DIFF
--- a/src/modules/snobal.hpp
+++ b/src/modules/snobal.hpp
@@ -87,7 +87,7 @@ public:
  * - Surface exchange layer temperature "T_s_0" [K]
  * - Lower layer temperature "T_s_l" [K]
  * - Was an iteration error hit "dead". Diagnostic, don't use. [-]
- * - Net shortwave radiation at the surface. Diagnostic. "iswr_out" [ \f$ W \cdot m^{-2} \f$ ]
+ * - Net shortwave radiation at the surface. Diagnostic. "iswr_net" [ \f$ W \cdot m^{-2} \f$ ]
  * - Binary is the snow isothermal "isothermal" [0,1]
  * - Outgoing longwave radiation "ilwr_out" [ \f$ W \cdot m^{-2} \f$ ]
  * - Total snowpack runoff "sum_snowpack_runoff"


### PR DESCRIPTION
## Summary
- update the Snobal module documentation to list `iswr_net` for net shortwave radiation
- match `src/modules/snobal.cpp`, which registers and writes `iswr_net`
- leave the separate Snowpack `iswr_out` documentation untouched

Addresses #162.

## Validation
- `rg -n 'iswr_net|iswr_out|provides\("iswr_net"|\["iswr_net"_s\]' src/modules/snobal.hpp src/modules/snobal.cpp src/modules/snowpack.hpp src/modules/snowpack.cpp`
- `python3` source assertion that `snobal.hpp` documents `iswr_net` and `snobal.cpp` provides/writes `iswr_net`
- `git diff --check`

## Not run
- `spack env activate chm`, `cmake`, `ctest`, and `clang-format`: the local environment does not have `spack`, `cmake`, or `clang-format` installed.
